### PR TITLE
patch: .prettier, IDE tabs - spaces issue

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,12 +1,12 @@
 {
-    "printWidth": 80,
-    "tabWidth": 4,
-    "useTabs": true,
-    "semi": true,
-    "singleQuote": true,
-    "trailingComma": "none",
-    "bracketSpacing": true,
-    "arrowParens": "avoid",
-    "htmlWhitespaceSensitivity": "ignore",
-    "endOfLine": "lf"
+	"printWidth": 80,
+	"tabWidth": 4,
+	"useTabs": false,
+	"semi": true,
+	"singleQuote": true,
+	"trailingComma": "none",
+	"bracketSpacing": true,
+	"arrowParens": "avoid",
+	"htmlWhitespaceSensitivity": "ignore",
+	"endOfLine": "lf"
 }

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -58,9 +58,7 @@ h3 {
 body {
     margin: 0;
     font-family: Arial, sans-serif;
-    transition:
-        background-color 0.3s ease-in-out,
-        color 0.3s ease-in-out;
+    transition: background-color 0.3s ease-in-out, color 0.3s ease-in-out;
 }
 
 /****** Header wrapper *****/
@@ -238,9 +236,7 @@ body {
 .movies {
     /* padding: 2rem 0; */
     color: var(--text-color);
-    transition:
-        background-color 0.3s ease-in-out,
-        color 0.3s ease-in-out;
+    transition: background-color 0.3s ease-in-out, color 0.3s ease-in-out;
 }
 
 .movies__title {


### PR DESCRIPTION
Issue:
<img width="1508" alt="image" src="https://github.com/user-attachments/assets/77007c03-38a5-4e0d-91af-7e0a67e019c9">
- incorrect .prettier setting (tabs/spaces) causes IDE/eslint conflict 
- potentially creates unreadable PRs if left unchanged

Fixed:
- now adjusted .prettier config to correct settings 