### PR TITLE
Refactor/pagination context

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { ThemeProvider } from './context/ThemeProvider';
 import { HomePage } from './components/HomePage';
@@ -22,28 +22,15 @@ const queryClient = new QueryClient({
 
 function App() {
     const [movies, setMovies] = useState([]);
-    // const [currentPage, setCurrentPage] = useState(1);
     const [totalPages, setTotalPages] = useState(0);
     const [totalResults, setTotalResults] = useState(0);
-
-    // const movies = await getServer();
 
     const handleSearch = searchResults => {
         console.log('Search Results:', searchResults);
         setMovies(searchResults.results);
         setTotalPages(searchResults.total_pages);
         setTotalResults(searchResults.total_results);
-        // setCurrentPage(1); // Reset to first page on new search
     };
-
-    // // Pagination
-    // const indexOfLastMovie = currentPage * moviesPerPage;
-    // const indexOfFirstMovie = indexOfLastMovie - moviesPerPage;
-    // const currentMovies = movies.slice(indexOfFirstMovie, indexOfLastMovie);
-    // console.log('Movies on current page:', currentMovies.length); // Add this log to see the number of movies
-
-    // Page change
-    // const paginate = pageNumber => setCurrentPage(pageNumber);
 
     return (
         // Provide the client to your App
@@ -58,12 +45,9 @@ function App() {
                                     <HomePage
                                         movies={movies}
                                         currentMovies={movies}
-                                        // currentPage={currentPage}
                                         totalPages={totalPages}
                                         totalResults={totalResults}
-                                        // paginate={paginate}
                                         handleSearch={handleSearch}
-                                        // setCurrentPage={setCurrentPage}
                                     />
                                 }
                             />
@@ -72,13 +56,10 @@ function App() {
                                 element={
                                     <SearchPage
                                         movies={movies}
-                                        // paginate={paginate}
-                                        // currentPage={currentPage}
                                         currentMovies={movies}
                                         totalResults={totalResults}
                                         totalPages={totalPages}
                                         handleSearch={handleSearch}
-                                        // setCurrentPage={setCurrentPage}
                                     />
                                 }
                             />

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -6,6 +6,7 @@ import { SearchPage } from './components/SearchPage';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import './App.css';
+import { PaginationProvider } from './context/PaginationProvider';
 
 // Create a client
 // Create a QueryClient with default options
@@ -21,7 +22,7 @@ const queryClient = new QueryClient({
 
 function App() {
     const [movies, setMovies] = useState([]);
-    const [currentPage, setCurrentPage] = useState(1);
+    // const [currentPage, setCurrentPage] = useState(1);
     const [totalPages, setTotalPages] = useState(0);
     const [totalResults, setTotalResults] = useState(0);
 
@@ -42,47 +43,49 @@ function App() {
     // console.log('Movies on current page:', currentMovies.length); // Add this log to see the number of movies
 
     // Page change
-    const paginate = pageNumber => setCurrentPage(pageNumber);
+    // const paginate = pageNumber => setCurrentPage(pageNumber);
 
     return (
         // Provide the client to your App
         <ThemeProvider>
-            <QueryClientProvider client={queryClient}>
-                <BrowserRouter>
-                    <Routes>
-                        <Route
-                            path="/"
-                            element={
-                                <HomePage
-                                    movies={movies}
-                                    currentMovies={movies}
-                                    currentPage={currentPage}
-                                    totalPages={totalPages}
-                                    totalResults={totalResults}
-                                    paginate={paginate}
-                                    handleSearch={handleSearch}
-                                    setCurrentPage={setCurrentPage}
-                                />
-                            }
-                        />
-                        <Route
-                            path="/search"
-                            element={
-                                <SearchPage
-                                    movies={movies}
-                                    paginate={paginate}
-                                    currentPage={currentPage}
-                                    currentMovies={movies}
-                                    totalResults={totalResults}
-                                    totalPages={totalPages}
-                                    handleSearch={handleSearch}
-                                    setCurrentPage={setCurrentPage}
-                                />
-                            }
-                        />
-                    </Routes>
-                </BrowserRouter>
-            </QueryClientProvider>
+            <PaginationProvider>
+                <QueryClientProvider client={queryClient}>
+                    <BrowserRouter>
+                        <Routes>
+                            <Route
+                                path="/"
+                                element={
+                                    <HomePage
+                                        movies={movies}
+                                        currentMovies={movies}
+                                        // currentPage={currentPage}
+                                        totalPages={totalPages}
+                                        totalResults={totalResults}
+                                        // paginate={paginate}
+                                        handleSearch={handleSearch}
+                                        // setCurrentPage={setCurrentPage}
+                                    />
+                                }
+                            />
+                            <Route
+                                path="/search"
+                                element={
+                                    <SearchPage
+                                        movies={movies}
+                                        // paginate={paginate}
+                                        // currentPage={currentPage}
+                                        currentMovies={movies}
+                                        totalResults={totalResults}
+                                        totalPages={totalPages}
+                                        handleSearch={handleSearch}
+                                        // setCurrentPage={setCurrentPage}
+                                    />
+                                }
+                            />
+                        </Routes>
+                    </BrowserRouter>
+                </QueryClientProvider>
+            </PaginationProvider>
         </ThemeProvider>
     );
 }

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -23,11 +23,7 @@ export const Header = ({ onSearch }) => {
                         />
                     </Link>
                     <div className="header__search-bar">
-                        <SearchBar
-                            onSearch={onSearch}
-                            // currentPage={currentPage}
-                            // setCurrentPage={setCurrentPage}
-                        />
+                        <SearchBar onSearch={onSearch} />
                     </div>
                     <div className="header__nav-icons">
                         <i className="fas fa-heart heart-icon"></i>

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -3,7 +3,7 @@ import { SearchBar } from './SearchBar';
 import { ThemeToggle } from './ThemeToggle';
 import { useTheme } from '../context/useTheme';
 
-export const Header = ({ onSearch, currentPage, setCurrentPage }) => {
+export const Header = ({ onSearch }) => {
     const { theme } = useTheme();
 
     return (
@@ -25,8 +25,8 @@ export const Header = ({ onSearch, currentPage, setCurrentPage }) => {
                     <div className="header__search-bar">
                         <SearchBar
                             onSearch={onSearch}
-                            currentPage={currentPage}
-                            setCurrentPage={setCurrentPage}
+                            // currentPage={currentPage}
+                            // setCurrentPage={setCurrentPage}
                         />
                     </div>
                     <div className="header__nav-icons">

--- a/client/src/components/HomePage.jsx
+++ b/client/src/components/HomePage.jsx
@@ -1,8 +1,13 @@
-import { useState } from 'react';
+import { useContext } from 'react';
 import { Header } from './Header';
 import { MovieCard } from './MovieCard';
 import { Pagination } from './Pagination';
 import { useQuery, keepPreviousData } from '@tanstack/react-query';
+import { usePaginationContext } from '../context/usePaginationContext';
+import {
+    PaginationContext,
+    PaginationProvider
+} from '../context/PaginationProvider';
 
 const popularMovies = currentPage => {
     console.log('popularMovies function called with currentPage:', currentPage);
@@ -24,14 +29,16 @@ const popularMovies = currentPage => {
 };
 export const HomePage = ({
     moviesPerPage = 8,
-    paginate,
-    currentPage,
+    // paginate,
+    // currentPage,
     handleSearch,
-    setCurrentPage,
+    // setCurrentPage,
     totalResults,
     totalPages,
     totalMovies = 20
 }) => {
+    // const { currentPage } = usePaginationContext();
+    const { currentPage } = useContext(PaginationContext);
     // Fetch popular movies using react-query
     console.log('HomePage component rendered');
     const { isLoading, isError, data, error, isFetching } = useQuery({
@@ -54,8 +61,8 @@ export const HomePage = ({
         <>
             <Header
                 onSearch={handleSearch}
-                currentPage={currentPage}
-                setCurrentPage={setCurrentPage}
+                // currentPage={currentPage}
+                // setCurrentPage={setCurrentPage}
             />
             <main className="main-content" role="main">
                 <section
@@ -83,10 +90,10 @@ export const HomePage = ({
                                 <Pagination
                                     moviesPerPage={moviesPerPage}
                                     totalMovies={totalMovies}
-                                    paginate={paginate}
-                                    currentPage={currentPage}
+                                    // paginate={paginate}
+                                    // currentPage={currentPage}
                                     totalPages={totalPages}
-                                    setCurrentPage={setCurrentPage}
+                                    // setCurrentPage={setCurrentPage}
                                 />
                             </div>
                         </>

--- a/client/src/components/HomePage.jsx
+++ b/client/src/components/HomePage.jsx
@@ -29,11 +29,7 @@ const popularMovies = currentPage => {
 };
 export const HomePage = ({
     moviesPerPage = 8,
-    // paginate,
-    // currentPage,
     handleSearch,
-    // setCurrentPage,
-    totalResults,
     totalPages,
     totalMovies = 20
 }) => {
@@ -47,10 +43,6 @@ export const HomePage = ({
         keepPreviousData: true
     });
 
-    // Calculate the first and last movie to display on the current page based on moviesPerPage
-    // const startIndex = (currentPage - 1) * moviesPerPage;
-    // const endIndex = startIndex + moviesPerPage;
-
     // console.log(data);
     // console.log(error);
     // console.log('Show data:', data.total_results);
@@ -59,11 +51,7 @@ export const HomePage = ({
 
     return (
         <>
-            <Header
-                onSearch={handleSearch}
-                // currentPage={currentPage}
-                // setCurrentPage={setCurrentPage}
-            />
+            <Header onSearch={handleSearch} />
             <main className="main-content" role="main">
                 <section
                     className="movies"
@@ -90,10 +78,7 @@ export const HomePage = ({
                                 <Pagination
                                     moviesPerPage={moviesPerPage}
                                     totalMovies={totalMovies}
-                                    // paginate={paginate}
-                                    // currentPage={currentPage}
                                     totalPages={totalPages}
-                                    // setCurrentPage={setCurrentPage}
                                 />
                             </div>
                         </>

--- a/client/src/components/Pagination.jsx
+++ b/client/src/components/Pagination.jsx
@@ -1,8 +1,10 @@
+import { usePaginationContext } from '../context/usePaginationContext';
+
 export const Pagination = ({
     moviesPerPage,
     totalMovies,
-    paginate,
-    currentPage,
+    // paginate,
+    // currentPage,
     totalPages
 }) => {
     console.log('Total Movies:', totalMovies);
@@ -10,6 +12,7 @@ export const Pagination = ({
 
     // console.log('Total Page Count:', totalPageCount);
 
+    const { currentPage, setCurrentPage } = usePaginationContext();
     // Hold the numbers of each page
     const pageNumbers = [];
 
@@ -20,14 +23,14 @@ export const Pagination = ({
     // If true, call the paginate function with current page minus 1
     const handlePrevClick = () => {
         if (currentPage > 1) {
-            paginate(currentPage - 1);
+            setCurrentPage(currentPage - 1);
         }
     };
     // Checks if current page number is less than the total number of pages.
     // If true, calls the paginate function with the current page # plus 1. Move to next page
     const handleNextClick = () => {
         if (currentPage < pageNumbers.length) {
-            paginate(currentPage + 1);
+            setCurrentPage(currentPage + 1);
         }
     };
 
@@ -62,7 +65,7 @@ export const Pagination = ({
                         }`}
                     >
                         <button
-                            onClick={() => paginate(number)}
+                            onClick={() => setCurrentPage(number)}
                             className="page-link"
                         >
                             {number}

--- a/client/src/components/Pagination.jsx
+++ b/client/src/components/Pagination.jsx
@@ -1,12 +1,6 @@
 import { usePaginationContext } from '../context/usePaginationContext';
 
-export const Pagination = ({
-    moviesPerPage,
-    totalMovies,
-    // paginate,
-    // currentPage,
-    totalPages
-}) => {
+export const Pagination = ({ moviesPerPage, totalMovies }) => {
     console.log('Total Movies:', totalMovies);
     console.log('Movies Per Page:', moviesPerPage);
 

--- a/client/src/components/SearchBar.jsx
+++ b/client/src/components/SearchBar.jsx
@@ -1,11 +1,14 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { usePaginationContext } from '../context/usePaginationContext';
 
-export const SearchBar = ({ onSearch, currentPage, setCurrentPage }) => {
+export const SearchBar = ({ onSearch }) => {
     const [searchParams, setSearchParams] = useSearchParams();
     const searchQueryParameter = searchParams.get('movie') || ''; // Get parameter from the URL
     const [searchQuery, setSearchQuery] = useState(searchQueryParameter);
     const navigate = useNavigate();
+
+    const { currentPage, setCurrentPage } = usePaginationContext();
 
     // Trigger initial search when the component mounts, using the query from the URL
     useEffect(() => {

--- a/client/src/components/SearchPage.jsx
+++ b/client/src/components/SearchPage.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { MovieCard } from './MovieCard';
 import { Header } from './Header';

--- a/client/src/components/SearchPage.jsx
+++ b/client/src/components/SearchPage.jsx
@@ -2,19 +2,22 @@ import { useSearchParams } from 'react-router-dom';
 import { MovieCard } from './MovieCard';
 import { Header } from './Header';
 import { Pagination } from './Pagination';
+import { usePaginationContext } from '../context/usePaginationContext';
 
 export const SearchPage = ({
     moviesPerPage = 20,
-    paginate,
-    currentPage,
+    // paginate,
+    // currentPage,
     currentMovies,
     totalResults,
     totalPages,
-    handleSearch,
-    setCurrentPage
+    handleSearch
+    // setCurrentPage
 }) => {
     const [searchParams] = useSearchParams();
     console.log(searchParams.get('movie'));
+
+    const { currentPage, setCurrentPage } = usePaginationContext();
 
     // console.log(searchResults);
     return (
@@ -50,9 +53,9 @@ export const SearchPage = ({
                         <Pagination
                             moviesPerPage={moviesPerPage}
                             totalMovies={totalResults}
-                            paginate={paginate}
-                            currentPage={currentPage}
-                            setCurrentPage={setCurrentPage}
+                            // paginate={paginate}
+                            // currentPage={currentPage}
+                            // setCurrentPage={setCurrentPage}
                         />
                     </div>
                 </section>

--- a/client/src/components/SearchPage.jsx
+++ b/client/src/components/SearchPage.jsx
@@ -6,13 +6,9 @@ import { usePaginationContext } from '../context/usePaginationContext';
 
 export const SearchPage = ({
     moviesPerPage = 20,
-    // paginate,
-    // currentPage,
     currentMovies,
     totalResults,
-    totalPages,
     handleSearch
-    // setCurrentPage
 }) => {
     const [searchParams] = useSearchParams();
     console.log(searchParams.get('movie'));
@@ -53,9 +49,6 @@ export const SearchPage = ({
                         <Pagination
                             moviesPerPage={moviesPerPage}
                             totalMovies={totalResults}
-                            // paginate={paginate}
-                            // currentPage={currentPage}
-                            // setCurrentPage={setCurrentPage}
                         />
                     </div>
                 </section>

--- a/client/src/context/PaginationProvider.jsx
+++ b/client/src/context/PaginationProvider.jsx
@@ -1,0 +1,17 @@
+import { createContext, useState } from 'react';
+
+export const PaginationContext = createContext();
+
+export const PaginationProvider = ({ children }) => {
+    const [currentPage, setCurrentPage] = useState(1);
+    return (
+        <PaginationContext.Provider
+            value={{
+                currentPage,
+                setCurrentPage
+            }}
+        >
+            {children}
+        </PaginationContext.Provider>
+    );
+};

--- a/client/src/context/usePaginationContext.jsx
+++ b/client/src/context/usePaginationContext.jsx
@@ -1,0 +1,4 @@
+import { useContext } from 'react';
+import { PaginationContext } from './PaginationProvider';
+
+export const usePaginationContext = () => useContext(PaginationContext);


### PR DESCRIPTION
### **Before Refactor:**
![Screenshot 2024-09-23 at 6 08 54 PM](https://github.com/user-attachments/assets/db6d82bd-3506-49d9-9829-3fd100596b78)

* `currentPage` and `setCurrentPage` were passed as props between components, a pattern known as 'prop drilling'.
> HomePage, SearchPage, SearchBar, Header, and Pagination

* Every time `currentPage` or `setCurrentPage` changes, all those components that receive these props will unnecessarily re-render.
* When a pagination button is clicked, React may re-render not only the pagination component but also other components that depend on `currentPage`.

### **After Refactor:**
![Screenshot 2024-09-23 at 6 24 39 PM](https://github.com/user-attachments/assets/f9caed78-4768-4f1d-917b-50be50490422)

* Improved maintainability
* Centralized pagination state by storing in the `PaginationContext`, eliminating the need to pass `currentPage` and `setCurrentPage` through props, abstracted the state management.
* By using `usePaginationContext`, any component that needs to interact with pagination can access `currentPage` and `setCurrentPage`, via `usePaginationContext`.
* only the `Pagination` component and other components that depend on the pagination state will re-render when it changes, while unaffected components will stay the same.