### PR TITLE
Refactor/use context tests

### DIFF
--- a/client/src/__tests__/Pagination.test.jsx
+++ b/client/src/__tests__/Pagination.test.jsx
@@ -101,7 +101,7 @@ describe('Pagination Component', () => {
     it('should go to the previous page on Previous button click', () => {
         const mockSetCurrentPage = vi.fn();
         usePaginationContext.mockReturnValue({
-            currentPage: 5,
+            currentPage: 4,
             setCurrentPage: mockSetCurrentPage
         });
 
@@ -110,6 +110,6 @@ describe('Pagination Component', () => {
         const prevButton = screen.getByLabelText('Previous Page');
         fireEvent.click(prevButton);
 
-        expect(mockSetCurrentPage).toHaveBeenCalledWith(4);
+        expect(mockSetCurrentPage).toHaveBeenCalledWith(3);
     });
 });

--- a/client/src/__tests__/Pagination.test.jsx
+++ b/client/src/__tests__/Pagination.test.jsx
@@ -2,76 +2,114 @@
 // https://testing-library.com/docs/react-testing-library/api/
 // https://vitest.dev/guide/testing-types.html
 
+import { PaginationProvider } from '../context/PaginationProvider';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { Pagination } from '../components/Pagination';
-import { expect, test, vi } from 'vitest';
+import { expect, vi, it, describe } from 'vitest';
+import { usePaginationContext } from '../context/usePaginationContext';
 
-test('correct page number when page button is clicked', () => {
-    const mockPaginate = vi.fn();
+vi.mock('../context/usePaginationContext', () => ({
+    usePaginationContext: vi.fn(() => ({
+        currentPage: 1, // Default value for currentPage
+        setCurrentPage: vi.fn() // Default mock function for setCurrentPage
+    }))
+}));
 
-    render(
-        <Pagination
-            moviesPerPage={8}
-            totalMovies={20}
-            currentPage={2}
-            paginate={mockPaginate}
-        />
-    );
-    // Clicking on page 2 to see if paginate is called
-    const pageTwo = screen.getByText('2');
-    fireEvent.click(pageTwo);
-
-    expect(mockPaginate).toHaveBeenCalledWith(2);
-});
-
-test('when Next and Back buttons are clicked', () => {
-    const mockPaginate = vi.fn();
-
-    render(
-        <Pagination
-            moviesPerPage={8}
-            totalMovies={20}
-            currentPage={2}
-            paginate={mockPaginate}
-        />
-    );
-
-    const nextButton = screen.getByLabelText('Next Page');
-    const backButton = screen.getByLabelText('Previous Page');
-
-    fireEvent.click(nextButton);
-    expect(mockPaginate).toHaveBeenCalledWith(3);
-
-    fireEvent.click(backButton);
-    expect(mockPaginate).toHaveBeenCalledWith(1);
-});
-
-test('renders Previous and Next buttons', () => {
-    render(
-        <Pagination
-            moviesPerPage={8}
-            totalMovies={20}
-            currentPage={2}
-            paginate={() => {}}
-        />
-    );
-    const nextButton = screen.getByLabelText('Next Page');
-    const backButton = screen.getByLabelText('Previous Page');
-
-    expect(nextButton).toBeTruthy();
-    expect(backButton).toBeTruthy();
-});
-
-test('disables Next button on last page'),
-    () => {
+describe('Pagination Component', () => {
+    const renderPagination = () =>
         render(
-            <Pagination
-                moviesPerPage={8}
-                totalMovies={20}
-                currentPage={2}
-                paginate={() => {}}
-            />
+            <PaginationProvider>
+                <Pagination moviesPerPage={8} totalMovies={20} />
+            </PaginationProvider>
         );
+    it('should update the current page when a page number is clicked', () => {
+        renderPagination();
+
+        const pageOneButton = screen.getByText('1');
+        fireEvent.click(pageOneButton);
+    });
+
+    it('should check the current page button is marked as active', () => {
+        renderPagination();
+
+        const pageOneButton = screen.getByText('1');
+
+        // Find the closest <li> parent to check if the 'active' class is applied
+        const pageOneListItem = pageOneButton.closest('li');
+        expect(pageOneListItem.classList.contains('active')).toBe(true);
+    });
+
+    it('should display the correct page number when clicked', () => {
+        renderPagination();
+
+        const nextButton = screen.getByLabelText('Next Page');
+        const prevButton = screen.getByLabelText('Previous Page');
+
+        expect(nextButton).toBeTruthy();
+        expect(prevButton).toBeTruthy();
+    });
+
+    it('should render Previous and Next button', () => {
+        renderPagination();
+
+        const nextButton = screen.getByLabelText('Next Page');
+        const backButton = screen.getByLabelText('Previous Page');
+
+        expect(nextButton).toBeTruthy();
+        expect(backButton).toBeTruthy();
+    });
+
+    it('disables Next button on last page', () => {
+        renderPagination();
+
         const nextButton = screen.getByLabelText('Next Page');
         expect(nextButton).toBeTruthy();
-    };
+    });
+
+    it('disables Previous button on first page', () => {
+        renderPagination();
+
+        const prevButton = screen.getByLabelText('Previous Page');
+        expect(prevButton.disabled).toBe(true);
+    });
+
+    it('should go to the next page on Next button click', () => {
+        // Mock specific behavior for this test
+        let mockCurrentPage = 2; // Track the current page manually
+        const mockSetCurrentPage = vi.fn(newPage => {
+            mockCurrentPage = newPage; // Update the page manually when setCurrentPage is called
+        });
+
+        usePaginationContext.mockReturnValue({
+            currentPage: mockCurrentPage, // starting page
+            setCurrentPage: mockSetCurrentPage
+        });
+
+        renderPagination();
+
+        const nextButton = screen.getByLabelText('Next Page');
+        const previousButton = screen.getByLabelText('Previous Page');
+
+        fireEvent.click(nextButton);
+
+        fireEvent.click(previousButton);
+
+        // Check if setCurrentPage was called with 2, then with 1
+        expect(mockSetCurrentPage).toHaveBeenCalledWith(3);
+    });
+
+    it('should go to the previous page on Previous button click', () => {
+        const mockSetCurrentPage = vi.fn();
+        usePaginationContext.mockReturnValue({
+            currentPage: 5,
+            setCurrentPage: mockSetCurrentPage
+        });
+
+        renderPagination();
+
+        const prevButton = screen.getByLabelText('Previous Page');
+        fireEvent.click(prevButton);
+
+        expect(mockSetCurrentPage).toHaveBeenCalledWith(4);
+    });
+});

--- a/client/src/components/Pagination.jsx
+++ b/client/src/components/Pagination.jsx
@@ -1,9 +1,6 @@
 import { usePaginationContext } from '../context/usePaginationContext';
 
 export const Pagination = ({ moviesPerPage, totalMovies }) => {
-    console.log('Total Movies:', totalMovies);
-    console.log('Movies Per Page:', moviesPerPage);
-
     // console.log('Total Page Count:', totalPageCount);
 
     const { currentPage, setCurrentPage } = usePaginationContext();


### PR DESCRIPTION
### **Before Refactor**

### **Issues:**
**1. Tests failed**
<img width="635" alt="Screenshot 2024-10-05 at 1 08 55 AM" src="https://github.com/user-attachments/assets/52ef0214-41bd-47c8-b8e9-871648ccf9ea">
this code was before the refactor:
<img width="399" alt="Screenshot 2024-10-04 at 8 57 03 PM" src="https://github.com/user-attachments/assets/f83e4f8d-49e4-4ff2-a959-ba012227a556">

* All tests failed due to state (currentPage, setCurrentPage) was moved from props to PaginationContext. Breaking the original tests that relied on passing these props directly.
* No access to state in the component since `PaginationProvider` was not used, and `usePaginationContext` could not provide values without it.
* Component's behaviour depended on manually passing props, which worked before the refactor but became incompatible with the next context-based approach.

**2. Render redundancy**
<img width="603" alt="Screenshot 2024-10-04 at 9 42 01 PM" src="https://github.com/user-attachments/assets/73790f42-8d4a-4a13-b458-33f39f10f414">

* Repeated the same rendering logic in every test.

### **After Refactor**

<img width="424" alt="Screenshot 2024-10-05 at 12 06 19 AM" src="https://github.com/user-attachments/assets/865feefb-588c-4df3-a9a6-606580dd5d99">

* Wrapped the Pagination component with PaginationProvider, which allows shared state values (currentPage and setCurrentPage) to be accessed by components.
* Included the values of `moviesPerPage` and `totalMovies` into the Pagination component because the component needs data to calculate and mock the function.
* Created a helper function to reduce render redundancy in each test.

_Note about mocking context provider:_

* Before the refactor, `mockPaginate = vi.fn()` to mock the paginate function.
* You cannot directly mock `useContext` using `vi.fn()` or any other mocking function because `useContext` is a built-in React hook that behaves internally within React's component lifecycle.
* use `vi.mock()` for mocking the module. 

<img width="483" alt="Screenshot 2024-10-05 at 1 01 51 AM" src="https://github.com/user-attachments/assets/f9189867-c655-4c4a-811b-028ae7d314a6">
