### PR TITLE
Replace fetch with Axios for API requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import express from 'express';
 import dotenv from 'dotenv';
 import { setTimeout as sleep } from 'node:timers/promises';
@@ -25,14 +26,24 @@ async function popularMoviesHandler(request, response) {
     // const { query, currentPage } = request.body;
     console.log('Page requested', page);
     try {
-        const tmdbResponse = await fetch(
-            `https://api.themoviedb.org/3/movie/popular?api_key=${process.env.TMDB_API_KEY}&language=en-US&page=1`,
+        const tmdbResponse = await axios.get(
+            // `https://api.themoviedb.org/3/movie/popular?api_key=${process.env.TMDB_API_KEY}&language=en-US&page=1`,
+            `https://api.themoviedb.org/3/movie/popular`,
             {
-                method: 'GET',
+                params: {
+                    api_key: process.env.TMDB_API_KEY,
+                    language: 'en-US',
+                    page: 1
+                },
+                // Remove GET in config because `axios.get` already implies the GET method
+                // method: 'GET',
                 headers: { 'Content-Type': 'application/json' }
             }
         );
-        const tmdbResponseJSON = await tmdbResponse.json();
+
+        // Remove 'await' and 'json()'
+        // Axios automatically parses the JSON response, so there’s no need to call .json() on it.
+        const tmdbResponseJSON = tmdbResponse.data;
 
         // // Limit to 20 movies in total
         let allResults = tmdbResponseJSON.results;
@@ -88,16 +99,30 @@ async function searchHandler(request, response) {
     }
 
     try {
-        const tmdbResponse = await fetch(
-            `https://api.themoviedb.org/3/search/movie?api_key=${
-                process.env.TMDB_API_KEY
-            }&query=${query}&page=${currentPage || 1}`,
+        const tmdbResponse = await axios.get(
+            //
+            // `https://api.themoviedb.org/3/search/movie?api_key=${
+            //     process.env.TMDB_API_KEY
+            // }&query=${query}&page=${currentPage || 1}`,
+            // {
+            //     // method: 'GET',
+            //     headers: { 'Content-Type': 'application/json' }
+            // }
+
+            // Axios `params` for cleaner and more secure query parameter handling.
+            `https://api.themoviedb.org/3/search/movie`,
             {
-                method: 'GET',
+                param: {
+                    api_key: process.env.TMDB_API_KEY,
+                    query: query,
+                    page: currentPage || 1
+                },
                 headers: { 'Content-Type': 'application/json' }
             }
         );
-        const tmdbResponseJSON = await tmdbResponse.json();
+
+        // const tmdbResponseJSON = await tmdbResponse.json();
+        const tmdbResponseJSON = tmdbResponse.data;
 
         const parsedResults = tmdbResponseJSON.results.map(movie => {
             let genreStorage = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.0.0",
 			"license": "ISC",
 			"dependencies": {
+				"axios": "^1.7.7",
 				"dotenv": "^16.4.5",
 				"express": "^4.19.2"
 			},
@@ -45,6 +46,21 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+		},
+		"node_modules/axios": {
+			"version": "1.7.7",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+			"integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+			"dependencies": {
+				"follow-redirects": "^1.15.6",
+				"form-data": "^4.0.0",
+				"proxy-from-env": "^1.1.0"
+			}
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
@@ -159,6 +175,17 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -219,6 +246,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/depd": {
@@ -362,6 +397,38 @@
 			},
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/follow-redirects": {
+			"version": "1.15.9",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+			"integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/form-data": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+			"integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/forwarded": {
@@ -778,6 +845,11 @@
 				"node": ">= 0.10"
 			}
 		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+		},
 		"node_modules/pstree.remy": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -1077,6 +1149,21 @@
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
 		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+		},
+		"axios": {
+			"version": "1.7.7",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+			"integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+			"requires": {
+				"follow-redirects": "^1.15.6",
+				"form-data": "^4.0.0",
+				"proxy-from-env": "^1.1.0"
+			}
+		},
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1160,6 +1247,14 @@
 				"readdirp": "~3.6.0"
 			}
 		},
+		"combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"requires": {
+				"delayed-stream": "~1.0.0"
+			}
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1206,6 +1301,11 @@
 				"es-errors": "^1.3.0",
 				"gopd": "^1.0.1"
 			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
 		},
 		"depd": {
 			"version": "2.0.0",
@@ -1314,6 +1414,21 @@
 				"parseurl": "~1.3.3",
 				"statuses": "2.0.1",
 				"unpipe": "~1.0.0"
+			}
+		},
+		"follow-redirects": {
+			"version": "1.15.9",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+			"integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
+		},
+		"form-data": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+			"integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
 			}
 		},
 		"forwarded": {
@@ -1595,6 +1710,11 @@
 				"forwarded": "0.2.0",
 				"ipaddr.js": "1.9.1"
 			}
+		},
+		"proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
 		},
 		"pstree.remy": {
 			"version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 	},
 	"homepage": "https://github.com/samantha-t28/movie-vault#readme",
 	"dependencies": {
+		"axios": "^1.7.7",
 		"dotenv": "^16.4.5",
 		"express": "^4.19.2"
 	},


### PR DESCRIPTION
# Axios Integration

<img width="795" alt="Screenshot 2024-10-30 at 11 57 04 AM" src="https://github.com/user-attachments/assets/d59919ee-0a6c-4c0c-9368-63fed4593fe3">

- Replaced fetch  with `axios.get`
- Removed `method:GET` in config because `axios.get` already implies the GET method

<img width="615" alt="Screenshot 2024-10-30 at 11 58 33 AM" src="https://github.com/user-attachments/assets/a06f8582-ca46-4fe5-aa99-d2fc3e308b1e">

- Used params object within the Axios configuration allows you to pass query parameters (api_key, language, and page) directly to the URL. Axios appends these parameters to the URL automatically, simplifying how query strings are managed.
- Improves readability

<img width="431" alt="Screenshot 2024-10-30 at 12 02 31 PM" src="https://github.com/user-attachments/assets/dc944494-46da-4b6d-9f28-38aff762880a">

- Removed `await` and `.json()` as Axios automatically parses JSON responses.
- Now we can access the data directly with `tmdbResponse.data`.
