### PR TITLE
Fix/pagination search page

### DIFF
--- a/client/src/components/Pagination.jsx
+++ b/client/src/components/Pagination.jsx
@@ -4,12 +4,22 @@ export const Pagination = ({ moviesPerPage, totalMovies }) => {
     // console.log('Total Page Count:', totalPageCount);
 
     const { currentPage, setCurrentPage } = usePaginationContext();
+    // Calculate how many pages is needed
+    const totalPages = Math.ceil(totalMovies / moviesPerPage);
     // Hold the numbers of each page
     const pageNumbers = [];
 
-    for (let i = 1; i <= Math.ceil(totalMovies / moviesPerPage); i++) {
+    // Show only first 6 pages
+    const maxVisiblePages = 6;
+
+    // Only show page numbers up to the smaller of totalPages or maxVisiblePages
+    for (let i = 1; i <= Math.min(totalPages, maxVisiblePages); i++) {
         pageNumbers.push(i);
     }
+
+    // for (let i = 1; i <= Math.ceil(totalMovies / moviesPerPage); i++) {
+    //     pageNumbers.push(i);
+    // }
     // pageNumbers.pop();
     // Checks if current page is greater than 1.
     // If true, call the paginate function with current page minus 1
@@ -21,7 +31,7 @@ export const Pagination = ({ moviesPerPage, totalMovies }) => {
     // Checks if current page number is less than the total number of pages.
     // If true, calls the paginate function with the current page # plus 1. Move to next page
     const handleNextClick = () => {
-        if (currentPage < pageNumbers.length) {
+        if (currentPage < totalPages) {
             setCurrentPage(currentPage + 1);
         }
     };
@@ -64,10 +74,18 @@ export const Pagination = ({ moviesPerPage, totalMovies }) => {
                         </button>
                     </li>
                 ))}
+                {/** Static Ellipsis Button - logic not implemented yet */}
+                {totalPages > maxVisiblePages && (
+                    <li className="page-item">
+                        <span className="page-link" aria-hidden="true">
+                            ...
+                        </span>
+                    </li>
+                )}
                 {/** <li> element checks if current page is the last page. If true, add 'disabled' class */}
                 <li
                     className={`page-item ${
-                        currentPage === pageNumbers.length ? 'disabled' : ''
+                        currentPage === totalPages ? 'disabled' : ''
                     }`}
                 >
                     {/** Next Page Button */}
@@ -76,7 +94,7 @@ export const Pagination = ({ moviesPerPage, totalMovies }) => {
                         aria-label="Next Page"
                         onClick={handleNextClick}
                         className="page-link"
-                        disabled={currentPage === pageNumbers.length}
+                        disabled={currentPage === totalPages}
                     >
                         <i className="fa-solid fa-arrow-right"></i>
                     </button>

--- a/client/src/components/Pagination.jsx
+++ b/client/src/components/Pagination.jsx
@@ -59,6 +59,7 @@ export const Pagination = ({ moviesPerPage, totalMovies }) => {
                 {/** Page Button */}
                 {/* iterates over the pageNumbers array and creates a button for each page number */}
                 {/** <li> element received 'active' class if it matches the 'currentPage' */}
+                {/** Render initial visiable pages */}
                 {pageNumbers.map(number => (
                     <li
                         key={number}
@@ -74,12 +75,27 @@ export const Pagination = ({ moviesPerPage, totalMovies }) => {
                         </button>
                     </li>
                 ))}
-                {/** Static Ellipsis Button - logic not implemented yet */}
+                {/** Render ellipsis */}
                 {totalPages > maxVisiblePages && (
                     <li className="page-item">
                         <span className="page-link" aria-hidden="true">
                             ...
                         </span>
+                    </li>
+                )}
+                {/** Render last page */}
+                {totalPages > maxVisiblePages && (
+                    <li
+                        className={`page-item ${
+                            currentPage === totalPages ? 'active' : ''
+                        }`}
+                    >
+                        <button
+                            onClick={() => setCurrentPage(totalPages)}
+                            className="page-link"
+                        >
+                            {totalPages}
+                        </button>
                     </li>
                 )}
                 {/** <li> element checks if current page is the last page. If true, add 'disabled' class */}
@@ -103,3 +119,9 @@ export const Pagination = ({ moviesPerPage, totalMovies }) => {
         </nav>
     );
 };
+
+// When page moves beyond page 6, shift the page numbers forward ( < 2 3 4 5 6 7 ... 10 >)
+// When page 10 is selected, display previous page numbers  < 1 ... 5 6 7 8 9 10 >
+
+// Always display up to 6 pages
+// IF more than 6, display ellipsis and the last page

--- a/client/src/components/Pagination.jsx
+++ b/client/src/components/Pagination.jsx
@@ -1,28 +1,59 @@
+import { useState, useEffect } from 'react';
 import { usePaginationContext } from '../context/usePaginationContext';
 
 export const Pagination = ({ moviesPerPage, totalMovies }) => {
     // console.log('Total Page Count:', totalPageCount);
-
+    console.log('--- Pagination Component is Rendering ---');
     const { currentPage, setCurrentPage } = usePaginationContext();
     // Calculate how many pages is needed
     const totalPages = Math.ceil(totalMovies / moviesPerPage);
-    // Hold the numbers of each page
-    const pageNumbers = [];
 
-    // Show only first 6 pages
-    const maxVisiblePages = 6;
+    // Use useState to store page number and render pages dynamically
+    const [pageNumbers, setPageNumbers] = useState([]);
+    useEffect(() => {
+        // Case 1: Not enough pages to need complex logic (Using the for loop method)
+        if (totalPages < 7) {
+            const pages = []; // Create an empty array
+            for (let i = 1; i <= totalPages; i++) {
+                pages.push(i); // Fill it
+            }
+            setPageNumbers(pages); // Set the state
+            return;
+        }
 
-    // Only show page numbers up to the smaller of totalPages or maxVisiblePages
-    for (let i = 1; i <= Math.min(totalPages, maxVisiblePages); i++) {
-        pageNumbers.push(i);
-    }
+        // Case 2: Current page is near the beginning
+        if (currentPage <= 4) {
+            setPageNumbers([1, 2, 3, 4, 5, 6, '...', totalPages]);
+            return;
+        }
 
-    // for (let i = 1; i <= Math.ceil(totalMovies / moviesPerPage); i++) {
-    //     pageNumbers.push(i);
-    // }
-    // pageNumbers.pop();
-    // Checks if current page is greater than 1.
-    // If true, call the paginate function with current page minus 1
+        // Case 3: Current page is near the end
+        if (currentPage >= totalPages - 3) {
+            setPageNumbers([
+                1,
+                '...',
+                totalPages - 5,
+                totalPages - 4,
+                totalPages - 3,
+                totalPages - 2,
+                totalPages - 1,
+                totalPages
+            ]);
+            return;
+        }
+
+        // Case 4: Current page is in the middle
+        setPageNumbers([
+            1,
+            '...',
+            currentPage - 1,
+            currentPage,
+            currentPage + 1,
+            '...',
+            totalPages
+        ]);
+    }, [currentPage, totalPages]);
+
     const handlePrevClick = () => {
         if (currentPage > 1) {
             setCurrentPage(currentPage - 1);
@@ -60,44 +91,33 @@ export const Pagination = ({ moviesPerPage, totalMovies }) => {
                 {/* iterates over the pageNumbers array and creates a button for each page number */}
                 {/** <li> element received 'active' class if it matches the 'currentPage' */}
                 {/** Render initial visiable pages */}
-                {pageNumbers.map(number => (
-                    <li
-                        key={number}
-                        className={`page-item ${
-                            currentPage === number ? 'active' : ''
-                        }`}
-                    >
-                        <button
-                            onClick={() => setCurrentPage(number)}
-                            className="page-link"
+                {pageNumbers.map((page, index) => {
+                    if (page === '...') {
+                        return (
+                            <li
+                                key={`ellipsis-${index}`}
+                                className="page-item disabled"
+                            >
+                                <span className="page-link">...</span>
+                            </li>
+                        );
+                    }
+                    return (
+                        <li
+                            key={page}
+                            className={`page-item ${
+                                currentPage === page ? 'active' : ''
+                            }`}
                         >
-                            {number}
-                        </button>
-                    </li>
-                ))}
-                {/** Render ellipsis */}
-                {totalPages > maxVisiblePages && (
-                    <li className="page-item">
-                        <span className="page-link" aria-hidden="true">
-                            ...
-                        </span>
-                    </li>
-                )}
-                {/** Render last page */}
-                {totalPages > maxVisiblePages && (
-                    <li
-                        className={`page-item ${
-                            currentPage === totalPages ? 'active' : ''
-                        }`}
-                    >
-                        <button
-                            onClick={() => setCurrentPage(totalPages)}
-                            className="page-link"
-                        >
-                            {totalPages}
-                        </button>
-                    </li>
-                )}
+                            <button
+                                onClick={() => setCurrentPage(page)}
+                                className="page-link"
+                            >
+                                {page}
+                            </button>
+                        </li>
+                    );
+                })}
                 {/** <li> element checks if current page is the last page. If true, add 'disabled' class */}
                 <li
                     className={`page-item ${

--- a/client/src/components/Pagination.jsx
+++ b/client/src/components/Pagination.jsx
@@ -2,14 +2,13 @@ import { useState, useEffect } from 'react';
 import { usePaginationContext } from '../context/usePaginationContext';
 
 export const Pagination = ({ moviesPerPage, totalMovies }) => {
-    // console.log('Total Page Count:', totalPageCount);
-    console.log('--- Pagination Component is Rendering ---');
     const { currentPage, setCurrentPage } = usePaginationContext();
     // Calculate how many pages is needed
     const totalPages = Math.ceil(totalMovies / moviesPerPage);
 
     // Use useState to store page number and render pages dynamically
     const [pageNumbers, setPageNumbers] = useState([]);
+
     useEffect(() => {
         // Case 1: Not enough pages to need complex logic (Using the for loop method)
         if (totalPages < 7) {
@@ -46,9 +45,11 @@ export const Pagination = ({ moviesPerPage, totalMovies }) => {
         setPageNumbers([
             1,
             '...',
+            currentPage - 2,
             currentPage - 1,
             currentPage,
             currentPage + 1,
+            currentPage + 2,
             '...',
             totalPages
         ]);
@@ -139,9 +140,3 @@ export const Pagination = ({ moviesPerPage, totalMovies }) => {
         </nav>
     );
 };
-
-// When page moves beyond page 6, shift the page numbers forward ( < 2 3 4 5 6 7 ... 10 >)
-// When page 10 is selected, display previous page numbers  < 1 ... 5 6 7 8 9 10 >
-
-// Always display up to 6 pages
-// IF more than 6, display ellipsis and the last page


### PR DESCRIPTION
Resolves #27


### Motivation

This PR resolves the issue of the pagination control rendered a button for every single page number. For search results with many pages(e.g., 40+), this created an overwhelming and unusable list of page buttons. That leads to the break of the component layout.

### Description

This PR resolves the issue by replacing the static logic and uses React hook to render the appropriate page numbers. The component is now correctly calculates and render relevant set of pages based on user's current position. This includes handling the "start," "middle," and "end" states appropriately and displaying ellipses for large page ranges, making the feature complete and functional.

### Changes Included

- The component was refactored to use React hooks.
- Added logic to correctly handle all three pagination states: start, middle, and end.
- Removed comments and console logs.

## Before
### Rendered a button for every single page
![Screenshot 2025-06-12 at 7 43 26 PM](https://github.com/user-attachments/assets/3862e20e-cd7f-404c-95e3-3e3e4113d6fb)

## After
### **Initial page load:** Renders the first 6 pages, an ellipsis and the last page number

![Screenshot 2025-06-12 at 7 44 34 PM](https://github.com/user-attachments/assets/73edcab6-3e26-424a-90bb-b98b55034e60)
### **When a middle page is active: (e.g., page 8)** The control displays the active page with 2 "neighbour" pages on each side, surrounded by ellipses

![Screenshot 2025-06-12 at 7 45 30 PM](https://github.com/user-attachments/assets/5040e0ce-cde2-42dc-b000-e25d87bef9e8)
### **When the last page is active:** Displays final 6 pages, an ellipsis and the first page number

![Screenshot 2025-06-12 at 7 46 04 PM](https://github.com/user-attachments/assets/8d7412d6-083a-4dbc-8304-9fcd2683e297)
