### PR TITLE
fix: browser back button not working on search page

### DIFF
--- a/client/src/components/SearchBar.jsx
+++ b/client/src/components/SearchBar.jsx
@@ -11,9 +11,6 @@ export const SearchBar = ({ onSearch }) => {
     const { currentPage, setCurrentPage } = usePaginationContext();
 
     // Trigger initial search when the component mounts, using the query from the URL
-    useEffect(() => {
-        handleSearch();
-    }, [currentPage]);
 
     useEffect(() => {
         setCurrentPage(1);
@@ -21,8 +18,6 @@ export const SearchBar = ({ onSearch }) => {
 
     const handleInputChange = event => {
         setSearchQuery(event.target.value);
-        // Updates the URL's query parameters with the current search input value
-        setSearchParams({ movie: event.target.value });
     };
 
     const handleSearch = async event => {


### PR DESCRIPTION
## Description

When a user searches for a movie and lands on the results page, pressing the browser back button doesn't take them back to the homepage.

## Fix

- Removing setSearchParams from handleInputChange so typing doesn't touch the
  URL or history                                                                
- Removing the navigate call from the useEffect so going back doesn't re-trigger navigation forward   